### PR TITLE
fix a bug in linked_list.py

### DIFF
--- a/docs/03_链表/linked_list.py
+++ b/docs/03_链表/linked_list.py
@@ -77,7 +77,10 @@ class LinkedList(object):
             if curnode.value == value:
                 prevnode.next = curnode.next
                 if curnode is self.tailnode:  # NOTE: 注意更新 tailnode
-                    self.tailnode = prevnode
+                    if prevnode is self.root:
+                        self.tailnode = None
+                    else:
+                        self.tailnode = prevnode
                 del curnode
                 self.length -= 1
                 return 1  # 表明删除成功


### PR DESCRIPTION
您好！我刚刚开始学习您的《Python 算法与数据结构视频教程》，现在只是看程序，还没看视频。在“单链表”的程序“linked_list.py”里面，我发现一处bug，就是在删除链表中的某个节点时，如果这个链表就剩这一个节点了，也就是该节点是第一个，也是最后一个节点的时候，会出现 `self.tailnode = prevnode = self.root` 的情况，而本来应该为 `self.tailnode = None` 的，这会造成一些问题。

我写了测试代码，如下图所示，可以发现其中的问题。
![1](https://user-images.githubusercontent.com/43639585/60768429-71040a80-a0f6-11e9-906b-3b27e3027034.png)

换成修改后的代码，问题不会再出现，如下图所示。
![2](https://user-images.githubusercontent.com/43639585/60768446-a14ba900-a0f6-11e9-836d-01e072465abd.png)
